### PR TITLE
PAY-8828: Add service contact for PCS and some minor perf fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ docker image rm <image-id>
 
 There is no need to remove postgres and java or similar core images.
 
+## Database indexing strategy
+
+When adding or changing repository query methods, keep database indexes aligned with query predicates and sort columns.
+
+- Liquibase changelogs are in `src/main/resources/db/changelog`.
+- Current query-driven index definitions are in `src/main/resources/db/changelog/db.changelog-0.9.yaml`.
+- Register any new changelog file in `src/main/resources/db/changelog/db.changelog-master.xml`.
+
+Current mappings:
+
+- `NotificationRepository.findByReferenceOrderByDateUpdatedDesc(...)` and `deleteByReference(...)`
+  -> `idx_notification_reference_date_updated` on `notification(reference, date_updated desc)`
+- `NotificationRepository.findByReferenceAndNotificationTypeOrderByDateUpdatedDesc(...)`
+  -> `idx_notification_ref_type_date_updated` on
+  `notification(reference, notification_type, date_updated desc)`
+- `ServiceContactRepository.findByServiceName(...)`
+  -> `idx_service_contact_service_name` on `service_contact(service_name)`
+
+Before merging DB index changes, run the project tests and ensure Liquibase migrations apply cleanly in your target environment.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ repositories {
 def versions = [
   log4j           : '2.25.3',
   lombok          : '1.18.42',
-  reformLogging   : '7.0.0',
+  reformLogging   : '8.0.0',
   springBoot      : springBoot.class.package.implementationVersion,
   jackson         : '2.19.2',
   restAssured     : '4.5.1',

--- a/charts/ccpay-notifications-service/Chart.yaml
+++ b/charts/ccpay-notifications-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for notifications-service App
 name: ccpay-notifications-service
 home: https://github.com/hmcts/ccpay-notifications-service
-version: 1.0.20
+version: 1.0.21
 maintainers:
   - name: HMCTS Fees and Pay team
 dependencies:

--- a/src/main/resources/db/changelog/db.changelog-0.8.yaml
+++ b/src/main/resources/db/changelog/db.changelog-0.8.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 100015
+      author: davidjones
+      changes:
+        - sql:
+            splitStatements: true
+            sql: >
+              INSERT INTO public.service_contact
+              (service_name, service_mailbox, from_email_address, from_mail_address)
+              VALUES('Mortgage and Landlord Possession Claims',
+                     'possession.support@justice.gov.uk',
+                     'possession.support@justice.gov.uk',
+                     NULL);
+

--- a/src/main/resources/db/changelog/db.changelog-0.9.yaml
+++ b/src/main/resources/db/changelog/db.changelog-0.9.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  # Supports NotificationRepository.findByReferenceOrderByDateUpdatedDesc(reference)
+  # and deleteByReference(reference), with ordering on latest updates.
+  - changeSet:
+      id: 100016
+      author: davidjones
+      changes:
+        - createIndex:
+            indexName: idx_notification_reference_date_updated
+            tableName: notification
+            columns:
+              - column:
+                  name: reference
+              - column:
+                  name: date_updated
+                  descending: true
+
+  # Supports NotificationRepository.findByReferenceAndNotificationTypeOrderByDateUpdatedDesc(
+  # reference, notificationType), including descending sort by date_updated.
+  - changeSet:
+      id: 100017
+      author: davidjones
+      changes:
+        - createIndex:
+            indexName: idx_notification_ref_type_date_updated
+            tableName: notification
+            columns:
+              - column:
+                  name: reference
+              - column:
+                  name: notification_type
+              - column:
+                  name: date_updated
+                  descending: true
+
+  # Supports ServiceContactRepository.findByServiceName(serviceName).
+  - changeSet:
+      id: 100018
+      author: davidjones
+      changes:
+        - createIndex:
+            indexName: idx_service_contact_service_name
+            tableName: service_contact
+            columns:
+              - column:
+                  name: service_name
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,4 +9,6 @@
   <include file="db/changelog/db.changelog-0.5.yaml"/>
   <include file="db/changelog/db.changelog-0.6.yaml"/>
   <include file="db/changelog/db.changelog-0.7.yaml"/>
+  <include file="db/changelog/db.changelog-0.8.yaml"/>
+  <include file="db/changelog/db.changelog-0.9.yaml"/>
 </databaseChangeLog>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-8828


### Change description ###
Added Liquibase migrations to insert the new Mortgage and Landlord Possession Claims service contact and introduced query-aligned DB indexes for notification and service_contact lookups.
Also updated changelog documentation in README.md to capture repository-to-index mapping guidance.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
